### PR TITLE
WOLO-65, WOLO-66, WOLO-84, PL/EN Translations And FE Tests

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4,7 +4,7 @@
   "calendar": "Calendar",
   "forVolunteers": "For Volunteers",
   "theyNeedYou": "They Need You",
-  "login": "Sing in",
+  "login": "Sign in",
 
   "back": "Back",
   "haveBeenSignedIn": "volunteers have been signed in",
@@ -12,12 +12,12 @@
   "date": "Date",
   "time": "Time",
   "category": "Category",
-  "organizer": "Ogranizer",
+  "organizer": "Organiser",
   "location": "Location",
   "signIn": "Sign In",
-  "moreEventsFromThisOrganizer": "More events from this organizer",
+  "moreEventsFromThisOrganizer": "More events from this organiser",
 
-  "organizedBy": "Organized By",
+  "organizedBy": "Organised By",
   "needed": "Needed",
   "signedIn": "Signed In",
   "organisations": "Organisations",
@@ -27,9 +27,9 @@
   "showFilters": "Show Filters",
   "hideFilters": "Hide Filters",
 
-  "welcome": "Are you ready to change the world ?",
+  "welcome": "Are you ready to change the world?",
   "signInToday": "Sign in",
   "or": "today or",
-  "findEvent": " find event to join",
+  "findEvent": "find an event to join",
   "mainSearch": "Search"
 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3,11 +3,11 @@
   "allEvents": "Wszystkie wydarzenia",
   "calendar": "Kalendarz",
   "forVolunteers": "Dla Wolontariuszy",
-  "theyNeedYou": "Potrzebują cię",
-  "login": "Zaloguj Się",
+  "theyNeedYou": "Potrzebują Ciebie",
+  "login": "Zaloguj się",
 
   "back": "Wróć",
-  "haveBeenSignedIn": "już zapisanych wolontariuszy",
+  "haveBeenSignedIn": "zapisanych wolontariuszy",
   "moreIsNeeded": "jeszcze potrzebnych",
   "date": "Data",
   "time": "Czas",
@@ -30,6 +30,6 @@
   "welcome": "Czy jesteś gotów zmienić świat ?",
   "signInToday": "Zaloguj się",
   "or": "już dziś lub",
-  "findEvent": "znadź wydarzenie dla siebie",
+  "findEvent": "znajdź wydarzenie dla siebie",
   "mainSearch": "Wyszukaj"
 }

--- a/src/Components/AllEvents/AllEvents.test.js
+++ b/src/Components/AllEvents/AllEvents.test.js
@@ -1,22 +1,21 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
-import i18n from 'i18next';
+import i18n from '../../i18nTests';
 import AllEvents from './AllEvents';
+import {BrowserRouter} from "react-router-dom";
+import {FiltersProvider} from "../Filters/FiltersContext";
 
 describe('AllEvents', () => {
-  beforeAll(() => {
-    i18n.init({
-      debug: true,
-      fallbackLng: 'en',
-    });
-  });
-
   it('should render without errors', () => {
     render(
-      <I18nextProvider i18n={i18n}>
-        <AllEvents />
-      </I18nextProvider>
+        <I18nextProvider i18n={i18n}>
+          <BrowserRouter>
+            <FiltersProvider>
+              <AllEvents />
+            </FiltersProvider>
+          </BrowserRouter>
+        </I18nextProvider>
     );
   });
 });

--- a/src/Components/Details/Details.test.js
+++ b/src/Components/Details/Details.test.js
@@ -1,22 +1,62 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { I18nextProvider } from 'react-i18next';
-import i18n from 'i18next';
+import {render, screen} from '@testing-library/react';
+import {I18nextProvider} from 'react-i18next';
+import i18n from '../../i18nTests';
 import Details from './Details';
+import {BrowserRouter} from "react-router-dom";
+import {FiltersProvider} from "../Filters/FiltersContext";
 
 describe('Details', () => {
-  beforeAll(() => {
-    i18n.init({
-      debug: true,
-      fallbackLng: 'en',
+    it('should render without errors', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Details/>
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
     });
-  });
 
-  it('should render without errors', () => {
-    render(
-      <I18nextProvider i18n={i18n}>
-        <Details />
-      </I18nextProvider>
-    );
-  });
+    it('should display event information correctly', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Details/>
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
+        const dateInfo = screen.getByText("Date:");
+        const timeInfo = screen.getByText("Time:");
+        const categoryInfo = screen.getByText("Category:");
+        const organizerInfo = screen.getByText("Organiser:");
+        expect(dateInfo).toBeInTheDocument();
+        expect(timeInfo).toBeInTheDocument();
+        expect(categoryInfo).toBeInTheDocument();
+        expect(organizerInfo).toBeInTheDocument();
+    });
+
+    it('should display event information correctly in Polish', () => {
+        i18n.changeLanguage("pl");
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Details/>
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
+        const dateInfo = screen.getByText("Data:");
+        const timeInfo = screen.getByText("Czas:");
+        const categoryInfo = screen.getByText("Kategoria:");
+        const organizerInfo = screen.getByText("Organizator:");
+        expect(dateInfo).toBeInTheDocument();
+        expect(timeInfo).toBeInTheDocument();
+        expect(categoryInfo).toBeInTheDocument();
+        expect(organizerInfo).toBeInTheDocument();
+    });
 });

--- a/src/Components/EventCard/EventCard.test.js
+++ b/src/Components/EventCard/EventCard.test.js
@@ -1,23 +1,77 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
-import i18n from 'i18next';
+import i18n from '../../i18nTests';
 import EventCard from './EventCard';
 import data from '../../eventsData.json';
+import {BrowserRouter} from "react-router-dom";
+import {FiltersProvider} from "../Filters/FiltersContext";
 
 describe('EventCard', () => {
-  beforeAll(() => {
-    i18n.init({
-      debug: true,
-      fallbackLng: 'en',
-    });
-  });
+
 
   it('should render without errors', () => {
     render(
-      <I18nextProvider i18n={i18n}>
-        <EventCard event={data} />
-      </I18nextProvider>
+        <I18nextProvider i18n={i18n}>
+          <BrowserRouter>
+            <FiltersProvider>
+              <EventCard event={data} />
+            </FiltersProvider>
+          </BrowserRouter>
+        </I18nextProvider>
     );
+  });
+
+  const event = {
+    id: 1,
+    title: "Darmowe obiady dla potrzebujących",
+    location: "Gdańsk - Wrzeszcz",
+    date: "2023-06-10",
+    time: "10:00",
+    organizedBy: "Fundacja Pomocna Dłoń",
+    participantsNeeded: 5,
+    participantsSignedIn: 3,
+    category: "Pomoc Społeczna",
+    ageRestrictions: "18+",
+    requiresVerification: true
+  };
+
+  it("should render EventCard without errors", () => {
+    render(
+        <I18nextProvider i18n={i18n}>
+          <BrowserRouter>
+            <EventCard event={event}/>
+          </BrowserRouter>
+        </I18nextProvider>
+    );
+
+    expect(screen.getByText("Darmowe obiady dla potrzebujących")).toBeInTheDocument();
+    expect(screen.getByText("Gdańsk - Wrzeszcz")).toBeInTheDocument();
+    expect(screen.getByText("2023-06-10")).toBeInTheDocument();
+    expect(screen.getByText("10:00")).toBeInTheDocument();
+    expect(screen.getByText("Fundacja Pomocna Dłoń")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("should display event information with Polish translation", () => {
+    // Ustaw język na polski
+    i18n.changeLanguage("pl");
+
+    render(
+        <I18nextProvider i18n={i18n}>
+          <BrowserRouter>
+            <EventCard event={event} />
+          </BrowserRouter>
+        </I18nextProvider>
+    );
+
+    // Oczekuj, że tłumaczenia na polski będą używane
+    expect(screen.getByText("Lokalizacja:")).toBeInTheDocument();
+    expect(screen.getByText("Data:")).toBeInTheDocument();
+    expect(screen.getByText("Czas:")).toBeInTheDocument();
+    expect(screen.getByText("Organizowany przez:")).toBeInTheDocument();
+    expect(screen.getByText("Potrzebnych wolonatriuszy:")).toBeInTheDocument();
+    expect(screen.getByText("Zapisanych wolontariuszy:")).toBeInTheDocument();
   });
 });

--- a/src/Components/Hero/Hero.js
+++ b/src/Components/Hero/Hero.js
@@ -45,7 +45,7 @@ const Hero = () => {
                             placeholderText="Select a date"
                             className="MainInput"
                         />
-                        <select id="selectInput_hero" className="MainInput">
+                        <select id="selectInput_hero" className="MainInput" data-testid="location-select">
                             <option value="" disabled selected>Location</option>
                             {locations.map((location, index) => (
                                 <option key={index} value={location}>

--- a/src/Components/Hero/Hero.test.js
+++ b/src/Components/Hero/Hero.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Hero from './Hero';
+import i18n from '../../i18nTests';
+import { I18nextProvider } from 'react-i18next';
+import { BrowserRouter } from 'react-router-dom';
+import { FiltersProvider } from '../Filters/FiltersContext';
+
+describe('Hero', () => {
+    it('should render without errors', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Hero />
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
+    });
+
+    it('should navigate to login and events pages', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Hero />
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
+
+        const signInLink = screen.getByText('Sign in');
+        const findEventLink = screen.getByText('find an event to join');
+
+        expect(signInLink).toBeInTheDocument();
+        expect(findEventLink).toBeInTheDocument();
+
+        fireEvent.click(signInLink);
+        expect(window.location.pathname).toBe('/login');
+
+        fireEvent.click(findEventLink);
+        expect(window.location.pathname).toBe('/events');
+    });
+
+    it('should handle date and location selection', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Hero />
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
+
+        const dateInput = screen.getByPlaceholderText('Select a date');
+        const locationSelect = screen.getByTestId("location-select");
+
+        fireEvent.change(dateInput, { target: { value: '10/06/2023' } });
+        expect(dateInput).toHaveValue('10/06/2023');
+
+        fireEvent.change(locationSelect, { target: { value: 'Zaspa' } });
+        expect(locationSelect).toHaveValue('Zaspa');
+    });
+});

--- a/src/Components/Navbar/Navbar.js
+++ b/src/Components/Navbar/Navbar.js
@@ -51,9 +51,10 @@ const Navbar = () => {
           </li>
           <li>
             <select
-              id="langauges-select"
+              id="languages-select"
               onChange={e => handleLanguageChange(e.target.value)}
               defaultValue={i18n.language}
+              data-testid="languages-select"
             >
               <option value="en">English</option>
               <option value="pl">Polish</option>
@@ -71,8 +72,9 @@ const Navbar = () => {
           onKeyPress={handleKeyPress}
           tabIndex={0}
           aria-label="Toggle Menu"
+          data-testid="mobile"
         >
-          <i id="bar" className={clicked ? 'fas fa-times' : 'fas fa-bars'}></i>
+          <i id="bar" className={clicked ? 'fas fa-times' : 'fas fa-bars'} data-testid="bar"></i>
         </button>
       </nav>
     </>

--- a/src/Components/Navbar/Navbar.test.js
+++ b/src/Components/Navbar/Navbar.test.js
@@ -1,22 +1,67 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { I18nextProvider } from 'react-i18next';
-import i18n from 'i18next';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {I18nextProvider} from 'react-i18next';
+import i18n from '../../i18nTests';
 import Navbar from './Navbar';
+import {BrowserRouter} from "react-router-dom";
+import {FiltersProvider} from "../Filters/FiltersContext";
 
 describe('Navbar', () => {
-  beforeAll(() => {
-    i18n.init({
-      debug: true,
-      fallbackLng: 'en',
+    it('should render without errors', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Navbar/>
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
     });
-  });
 
-  it('should render without errors', () => {
-    render(
-      <I18nextProvider i18n={i18n}>
-        <Navbar />
-      </I18nextProvider>
-    );
-  });
+    it('Navbar can change language to "pl" and updates text', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Navbar/>
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
+        const selectElement = screen.getByTestId('languages-select'); // Znajdź select
+
+        fireEvent.change(selectElement, {target: {value: 'pl'}});
+
+        expect(selectElement.value).toBe('pl');
+
+        const liElement = screen.getByText('Potrzebują Ciebie');
+
+        expect(liElement).toHaveTextContent('Potrzebują Ciebie');
+    });
+
+    it('Icon changes based on the initial state of "clicked"', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BrowserRouter>
+                    <FiltersProvider>
+                        <Navbar/>
+                    </FiltersProvider>
+                </BrowserRouter>
+            </I18nextProvider>
+        );
+
+        const mobileButton = screen.getByTestId('mobile');
+        const iconElement = screen.getByTestId('bar');
+
+        expect(iconElement).toHaveClass('fas fa-bars');
+
+        fireEvent.click(mobileButton);
+
+        expect(iconElement).toHaveClass('fas fa-times');
+
+        fireEvent.click(mobileButton);
+
+        expect(iconElement).toHaveClass('fas fa-bars');
+    });
 });

--- a/src/i18nTests.js
+++ b/src/i18nTests.js
@@ -1,0 +1,26 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import Backend from 'i18next-http-backend';
+
+i18n.use(initReactI18next).use(LanguageDetector).use(Backend).init({
+    debug: true,
+    fallbackLng: 'en',
+    lng: 'en',
+    resources: {
+        en: {
+            translation: require('../public/locales/en/translation.json'),
+        },
+        pl: {
+            translation: require('../public/locales/pl/translation.json'),
+        },
+        ru: {
+            translation: require('../public/locales/ru/translation.json'),
+        },
+        ua: {
+            translation: require('../public/locales/ua/translation.json'),
+        },
+    },
+});
+
+export default i18n;


### PR DESCRIPTION
Na naszym projektowym discordzie wyjaśnienie czemu jest ile jest 🕯️ 

Tłumaczenie języka polskiego i angielskiego jest na wzór tego, co moim zdaniem powinno być zawarte na stronie, przyjmuje wszystkie komentarze. Kluczową zmianą jest ustandaryzowanie tłumaczenie słowa "Organizator" na język angielski, jest on różny dla krajów brytyjskich i amerykańskich, "Organiser" jest formą stosowaną bliższym nam sąsiadom. 

Ta część jest skierowana głównie do ludzi zajmujących się frontem
- czym jest i18nTests.js? Jest to odpowiedni plik, który służy mi za źródło pozyskiwanie i18n do testów. Czemu to nie główny plik i18n.js? React współpracujący z i18n.js nie potrafi przyjąć plików spoza folderu "src", wywala cały front wtedy. Nie znalazłem innego rozwiązania tego problemu, oddzielenie i18n dla testów i dla Appki to najwygodniejsza opcja na ten moment
- testy oparte są na podstawach, żeby nie duplikować za bardzo potraktujcie to jako propozycje, w razie rozwoju projektu będzie można przekopiować itd. 
- niektóre komponenty dostały "data-testid", dla wygody pod testy

Struktura do renderowania komponentu pod testy:

`<I18nextProvider i18n={i18n}>`
`<BrowserRouter>`
`<FiltersProvider>`
`<All Events />`
`</FiltersProvider>`
`</BrowserRouter>`
`</I18nextProvider>`
            
Żaden komponent nie uruchomi się pod testy, które nie są czysto renderami, bez BrowserRouter, FiltersProvider jest potrzebny do każdego komponentu w którym operuje się na filtrach (jest w każdym z wygody własnej, optymalizacja i kolejna dawka testów będzie okazją na poprawienie tego, ale nie wpływa to negatywnie na testy, chodzi o estetykę i przejrzystość kodu).
Testów większych nie dostały: App, MoreEvents, Filters. W pierwszym i drugim można sprowadzić testy do renderów, nic więcej się nie wyciągnie, Filters dostanie przy następnej okazji, zależy mi na feedbacku.